### PR TITLE
Add My Account page to iOS app with passkey management

### DIFF
--- a/hamrahIOS/AddPasskeyView.swift
+++ b/hamrahIOS/AddPasskeyView.swift
@@ -1,0 +1,273 @@
+//
+//  AddPasskeyView.swift
+//  hamrahIOS
+//
+//  Add Passkey view for iOS app
+//
+
+import SwiftUI
+import AuthenticationServices
+
+struct AddPasskeyView: View {
+    @Environment(\.presentationMode) var presentationMode
+    @EnvironmentObject var authManager: NativeAuthManager
+    @State private var isLoading = false
+    @State private var errorMessage: String?
+    let onPasskeyAdded: () -> Void
+    
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 24) {
+                Spacer()
+                
+                // Icon
+                Image(systemName: "key.fill")
+                    .font(.system(size: 60))
+                    .foregroundColor(.blue)
+                
+                // Title and Description
+                VStack(spacing: 16) {
+                    Text("Add Passkey")
+                        .font(.title)
+                        .fontWeight(.bold)
+                    
+                    Text("Passkeys provide secure, passwordless authentication using your device's biometrics or PIN.")
+                        .font(.body)
+                        .multilineTextAlignment(.center)
+                        .foregroundColor(.secondary)
+                        .padding(.horizontal)
+                }
+                
+                Spacer()
+                
+                // Add Passkey Button
+                Button(action: addPasskey) {
+                    HStack {
+                        if isLoading {
+                            ProgressView()
+                                .scaleEffect(0.8)
+                                .tint(.white)
+                        } else {
+                            Image(systemName: "plus.circle.fill")
+                                .font(.title3)
+                        }
+                        Text(isLoading ? "Creating..." : "Add Passkey")
+                            .fontWeight(.semibold)
+                    }
+                    .foregroundColor(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.blue)
+                    .cornerRadius(12)
+                }
+                .disabled(isLoading)
+                
+                // Cancel Button
+                Button("Cancel") {
+                    presentationMode.wrappedValue.dismiss()
+                }
+                .foregroundColor(.secondary)
+                .disabled(isLoading)
+                
+                Spacer()
+            }
+            .padding()
+            .navigationTitle("Add Passkey")
+            .navigationBarTitleDisplayMode(.inline)
+            .navigationBarItems(trailing: Button("Done") {
+                presentationMode.wrappedValue.dismiss()
+            }.disabled(isLoading))
+            .alert("Error", isPresented: .constant(errorMessage != nil)) {
+                Button("OK") {
+                    errorMessage = nil
+                }
+            } message: {
+                Text(errorMessage ?? "")
+            }
+        }
+    }
+    
+    private func addPasskey() {
+        guard let user = authManager.currentUser,
+              let accessToken = authManager.accessToken else {
+            errorMessage = "Authentication required"
+            return
+        }
+        
+        isLoading = true
+        errorMessage = nil
+        
+        Task {
+            do {
+                try await registerPasskey(email: user.email, accessToken: accessToken)
+                await MainActor.run {
+                    self.isLoading = false
+                    self.onPasskeyAdded()
+                    self.presentationMode.wrappedValue.dismiss()
+                }
+            } catch {
+                await MainActor.run {
+                    self.errorMessage = "Failed to add passkey: \(error.localizedDescription)"
+                    self.isLoading = false
+                }
+            }
+        }
+    }
+    
+    private func registerPasskey(email: String, accessToken: String) async throws {
+        // Step 1: Begin WebAuthn registration
+        let beginOptions = try await beginWebAuthnRegistration(email: email, accessToken: accessToken)
+        
+        guard let options = beginOptions.options else {
+            throw NSError(domain: "WebAuthn", code: -1, userInfo: [NSLocalizedDescriptionKey: "No registration options received"])
+        }
+        
+        // Step 2: Perform platform registration
+        let attestation = try await performPlatformRegistration(options: options)
+        
+        // Step 3: Complete registration with backend
+        try await completeWebAuthnRegistration(attestation: attestation, email: email, accessToken: accessToken)
+    }
+    
+    private func beginWebAuthnRegistration(email: String, accessToken: String) async throws -> WebAuthnBeginRegistrationResponse {
+        let url = URL(string: "\(authManager.baseURL)/api/webauthn/register/begin")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("hamrah-ios", forHTTPHeaderField: "X-Requested-With")
+        
+        let body = ["email": email]
+        request.httpBody = try JSONEncoder().encode(body)
+        
+        let (data, _) = try await URLSession.shared.data(for: request)
+        return try JSONDecoder().decode(WebAuthnBeginRegistrationResponse.self, from: data)
+    }
+    
+    private func performPlatformRegistration(options: PublicKeyCredentialCreationOptions) async throws -> ASAuthorizationPlatformPublicKeyCredentialRegistration {
+        let challenge = Data(base64Encoded: options.challenge) ?? Data()
+        let userID = Data(base64Encoded: options.user.id) ?? Data()
+        
+        let request = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: options.rp.id)
+            .createCredentialRegistrationRequest(challenge: challenge, name: options.user.name, userID: userID)
+        
+        return try await withCheckedThrowingContinuation { continuation in
+            let controller = ASAuthorizationController(authorizationRequests: [request])
+            
+            // Store continuation for delegate callback
+            PasskeyRegistrationDelegate.shared.setContinuation(continuation)
+            
+            controller.delegate = PasskeyRegistrationDelegate.shared
+            controller.presentationContextProvider = authManager
+            controller.performRequests()
+        }
+    }
+    
+    private func completeWebAuthnRegistration(attestation: ASAuthorizationPlatformPublicKeyCredentialRegistration, email: String, accessToken: String) async throws {
+        let url = URL(string: "\(authManager.baseURL)/api/webauthn/register/complete")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("hamrah-ios", forHTTPHeaderField: "X-Requested-With")
+        
+        let body = [
+            "email": email,
+            "credentialId": attestation.credentialID.base64EncodedString(),
+            "attestationObject": attestation.rawAttestationObject?.base64EncodedString() ?? "",
+            "clientDataJSON": attestation.rawClientDataJSON.base64EncodedString()
+        ]
+        
+        request.httpBody = try JSONEncoder().encode(body)
+        
+        let (data, response) = try await URLSession.shared.data(for: request)
+        
+        guard let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 200 else {
+            throw NSError(domain: "WebAuthn", code: -1, userInfo: [NSLocalizedDescriptionKey: "Registration failed"])
+        }
+        
+        let apiResponse = try JSONDecoder().decode(APIResponse.self, from: data)
+        
+        if !apiResponse.success {
+            throw NSError(domain: "WebAuthn", code: -1, userInfo: [NSLocalizedDescriptionKey: apiResponse.error ?? "Registration failed"])
+        }
+    }
+}
+
+// MARK: - Data Models for Registration
+
+struct WebAuthnBeginRegistrationResponse: Codable {
+    let success: Bool
+    let options: PublicKeyCredentialCreationOptions?
+    let error: String?
+}
+
+struct PublicKeyCredentialCreationOptions: Codable {
+    let challenge: String
+    let rp: RelyingParty
+    let user: UserInfo
+    let pubKeyCredParams: [PubKeyCredParam]
+    let timeout: Int?
+    let excludeCredentials: [PublicKeyCredentialDescriptorForCreation]?
+    let authenticatorSelection: AuthenticatorSelection?
+}
+
+struct RelyingParty: Codable {
+    let id: String
+    let name: String
+}
+
+struct UserInfo: Codable {
+    let id: String
+    let name: String
+    let displayName: String
+}
+
+struct PubKeyCredParam: Codable {
+    let type: String
+    let alg: Int
+}
+
+struct AuthenticatorSelection: Codable {
+    let authenticatorAttachment: String?
+    let userVerification: String?
+    let requireResidentKey: Bool?
+}
+
+struct PublicKeyCredentialDescriptorForCreation: Codable {
+    let type: String
+    let id: String
+    let transports: [String]?
+}
+
+// MARK: - Passkey Registration Delegate
+
+class PasskeyRegistrationDelegate: NSObject, ASAuthorizationControllerDelegate {
+    static let shared = PasskeyRegistrationDelegate()
+    
+    private var continuation: CheckedContinuation<ASAuthorizationPlatformPublicKeyCredentialRegistration, Error>?
+    
+    func setContinuation(_ continuation: CheckedContinuation<ASAuthorizationPlatformPublicKeyCredentialRegistration, Error>) {
+        self.continuation = continuation
+    }
+    
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        if let registration = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialRegistration {
+            continuation?.resume(returning: registration)
+        } else {
+            continuation?.resume(throwing: NSError(domain: "PasskeyRegistration", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid credential type"]))
+        }
+        continuation = nil
+    }
+    
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        continuation?.resume(throwing: error)
+        continuation = nil
+    }
+}
+
+#Preview {
+    AddPasskeyView(onPasskeyAdded: {})
+        .environmentObject(NativeAuthManager())
+}

--- a/hamrahIOS/ContentView.swift
+++ b/hamrahIOS/ContentView.swift
@@ -40,8 +40,9 @@ struct ContentView: View {
                     }
                 }
                 ToolbarItem(placement: .navigationBarLeading) {
-                    Button("Logout") {
-                        authManager.logout()
+                    NavigationLink(destination: MyAccountView().environmentObject(authManager)) {
+                        Image(systemName: "person.circle")
+                            .font(.title3)
                     }
                 }
             }

--- a/hamrahIOS/MyAccountView.swift
+++ b/hamrahIOS/MyAccountView.swift
@@ -1,0 +1,362 @@
+//
+//  MyAccountView.swift
+//  hamrahIOS
+//
+//  My Account page for iOS app
+//
+
+import SwiftUI
+import AuthenticationServices
+
+struct MyAccountView: View {
+    @EnvironmentObject var authManager: NativeAuthManager
+    @State private var passkeys: [PasskeyCredential] = []
+    @State private var isLoading = false
+    @State private var errorMessage: String?
+    @State private var showConfirmDialog = false
+    @State private var credentialToDelete: PasskeyCredential?
+    @State private var showAddPasskey = false
+    
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(spacing: 20) {
+                    // User Information Section
+                    userInfoSection
+                    
+                    // Passkeys Section
+                    passkeysSection
+                    
+                    // Logout Section
+                    logoutSection
+                }
+                .padding()
+            }
+            .navigationTitle("My Account")
+            .navigationBarTitleDisplayMode(.large)
+            .onAppear {
+                loadPasskeys()
+            }
+            .alert("Error", isPresented: .constant(errorMessage != nil)) {
+                Button("OK") {
+                    errorMessage = nil
+                }
+            } message: {
+                Text(errorMessage ?? "")
+            }
+            .alert("Remove Passkey", isPresented: $showConfirmDialog) {
+                Button("Cancel", role: .cancel) {
+                    credentialToDelete = nil
+                }
+                Button("Remove", role: .destructive) {
+                    if let credential = credentialToDelete {
+                        removePasskey(credential)
+                    }
+                }
+            } message: {
+                Text("Are you sure you want to remove this passkey? This action cannot be undone.")
+            }
+        }
+    }
+    
+    private var userInfoSection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Account Information")
+                .font(.headline)
+                .padding(.horizontal)
+            
+            VStack(spacing: 12) {
+                if let user = authManager.currentUser {
+                    AccountInfoRow(label: "User ID", value: user.id)
+                    AccountInfoRow(label: "Email", value: user.email)
+                    AccountInfoRow(label: "Name", value: user.name ?? "Not provided")
+                    AccountInfoRow(label: "Auth Method", value: user.authMethod.capitalized)
+                    AccountInfoRow(label: "Member Since", value: formatDate(user.createdAt))
+                }
+            }
+            .padding()
+            .background(Color(.systemBackground))
+            .cornerRadius(12)
+            .shadow(color: .black.opacity(0.1), radius: 2, x: 0, y: 1)
+        }
+    }
+    
+    private var passkeysSection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                Text("Passkeys")
+                    .font(.headline)
+                
+                Spacer()
+                
+                Button("Add Passkey") {
+                    showAddPasskey = true
+                }
+                .font(.caption)
+                .foregroundColor(.blue)
+                .disabled(isLoading)
+            }
+            .padding(.horizontal)
+            
+            if isLoading {
+                ProgressView("Loading passkeys...")
+                    .frame(maxWidth: .infinity)
+                    .padding()
+            } else if passkeys.isEmpty {
+                VStack(spacing: 8) {
+                    Image(systemName: "key.fill")
+                        .font(.title2)
+                        .foregroundColor(.gray)
+                    Text("No passkeys found")
+                        .font(.caption)
+                        .foregroundColor(.gray)
+                    Text("Add a passkey for secure authentication")
+                        .font(.caption2)
+                        .foregroundColor(.gray)
+                        .multilineTextAlignment(.center)
+                }
+                .frame(maxWidth: .infinity)
+                .padding()
+                .background(Color(.systemBackground))
+                .cornerRadius(12)
+                .shadow(color: .black.opacity(0.1), radius: 2, x: 0, y: 1)
+            } else {
+                VStack(spacing: 8) {
+                    ForEach(passkeys) { passkey in
+                        PasskeyRow(
+                            passkey: passkey,
+                            onRemove: { credential in
+                                credentialToDelete = credential
+                                showConfirmDialog = true
+                            }
+                        )
+                    }
+                }
+                .padding()
+                .background(Color(.systemBackground))
+                .cornerRadius(12)
+                .shadow(color: .black.opacity(0.1), radius: 2, x: 0, y: 1)
+            }
+        }
+        .sheet(isPresented: $showAddPasskey) {
+            AddPasskeyView(onPasskeyAdded: {
+                loadPasskeys()
+            })
+            .environmentObject(authManager)
+        }
+    }
+    
+    private var logoutSection: some View {
+        VStack {
+            Button("Sign Out") {
+                authManager.logout()
+            }
+            .foregroundColor(.red)
+            .frame(maxWidth: .infinity)
+            .padding()
+            .background(Color(.systemBackground))
+            .cornerRadius(12)
+            .shadow(color: .black.opacity(0.1), radius: 2, x: 0, y: 1)
+        }
+    }
+    
+    private func formatDate(_ dateString: String) -> String {
+        let formatter = ISO8601DateFormatter()
+        if let date = formatter.date(from: dateString) {
+            let displayFormatter = DateFormatter()
+            displayFormatter.dateStyle = .medium
+            return displayFormatter.string(from: date)
+        }
+        return dateString
+    }
+    
+    private func loadPasskeys() {
+        guard let accessToken = authManager.accessToken else { return }
+        
+        isLoading = true
+        errorMessage = nil
+        
+        Task {
+            do {
+                let credentials = try await fetchPasskeys(accessToken: accessToken)
+                await MainActor.run {
+                    self.passkeys = credentials
+                    self.isLoading = false
+                }
+            } catch {
+                await MainActor.run {
+                    self.errorMessage = "Failed to load passkeys: \(error.localizedDescription)"
+                    self.isLoading = false
+                }
+            }
+        }
+    }
+    
+    private func removePasskey(_ credential: PasskeyCredential) {
+        guard let accessToken = authManager.accessToken else { return }
+        
+        Task {
+            do {
+                try await deletePasskey(credentialId: credential.id, accessToken: accessToken)
+                await MainActor.run {
+                    self.passkeys.removeAll { $0.id == credential.id }
+                    self.credentialToDelete = nil
+                }
+            } catch {
+                await MainActor.run {
+                    self.errorMessage = "Failed to remove passkey: \(error.localizedDescription)"
+                    self.credentialToDelete = nil
+                }
+            }
+        }
+    }
+    
+    private func fetchPasskeys(accessToken: String) async throws -> [PasskeyCredential] {
+        let url = URL(string: "\(authManager.baseURL)/api/webauthn/credentials")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("hamrah-ios", forHTTPHeaderField: "X-Requested-With")
+        
+        let (data, response) = try await URLSession.shared.data(for: request)
+        
+        guard let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 200 else {
+            throw NSError(domain: "API", code: -1, userInfo: [NSLocalizedDescriptionKey: "Failed to fetch passkeys"])
+        }
+        
+        let apiResponse = try JSONDecoder().decode(PasskeyListResponse.self, from: data)
+        
+        if apiResponse.success {
+            return apiResponse.credentials
+        } else {
+            throw NSError(domain: "API", code: -1, userInfo: [NSLocalizedDescriptionKey: apiResponse.error ?? "Unknown error"])
+        }
+    }
+    
+    private func deletePasskey(credentialId: String, accessToken: String) async throws {
+        let url = URL(string: "\(authManager.baseURL)/api/webauthn/credentials")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "DELETE"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("hamrah-ios", forHTTPHeaderField: "X-Requested-With")
+        
+        let body = ["credentialId": credentialId]
+        request.httpBody = try JSONEncoder().encode(body)
+        
+        let (data, response) = try await URLSession.shared.data(for: request)
+        
+        guard let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 200 else {
+            throw NSError(domain: "API", code: -1, userInfo: [NSLocalizedDescriptionKey: "Failed to delete passkey"])
+        }
+        
+        let apiResponse = try JSONDecoder().decode(APIResponse.self, from: data)
+        
+        if !apiResponse.success {
+            throw NSError(domain: "API", code: -1, userInfo: [NSLocalizedDescriptionKey: apiResponse.error ?? "Unknown error"])
+        }
+    }
+}
+
+struct AccountInfoRow: View {
+    let label: String
+    let value: String
+    
+    var body: some View {
+        HStack {
+            Text(label)
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .frame(width: 80, alignment: .leading)
+            
+            Text(value)
+                .font(.caption)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+struct PasskeyRow: View {
+    let passkey: PasskeyCredential
+    let onRemove: (PasskeyCredential) -> Void
+    
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Image(systemName: "key.fill")
+                        .font(.caption)
+                        .foregroundColor(.green)
+                    
+                    Text(passkey.name)
+                        .font(.caption)
+                        .fontWeight(.medium)
+                }
+                
+                Text("Created \(formatDate(passkey.createdAt))")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                
+                if let lastUsed = passkey.lastUsed {
+                    Text("Last used \(formatDate(lastUsed))")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+            }
+            
+            Spacer()
+            
+            Button("Remove") {
+                onRemove(passkey)
+            }
+            .font(.caption2)
+            .foregroundColor(.red)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(Color.red.opacity(0.1))
+            .cornerRadius(6)
+        }
+        .padding(.vertical, 8)
+    }
+    
+    private func formatDate(_ dateString: String) -> String {
+        let formatter = ISO8601DateFormatter()
+        if let date = formatter.date(from: dateString) {
+            let displayFormatter = DateFormatter()
+            displayFormatter.dateStyle = .short
+            return displayFormatter.string(from: date)
+        }
+        return dateString
+    }
+}
+
+// MARK: - Data Models
+
+struct PasskeyCredential: Codable, Identifiable {
+    let id: String
+    let name: String
+    let createdAt: String
+    let lastUsed: String?
+    let credentialDeviceType: String?
+    let credentialBackedUp: Bool?
+}
+
+struct PasskeyListResponse: Codable {
+    let success: Bool
+    let credentials: [PasskeyCredential]
+    let error: String?
+}
+
+struct APIResponse: Codable {
+    let success: Bool
+    let error: String?
+    let message: String?
+}
+
+#Preview {
+    MyAccountView()
+        .environmentObject(NativeAuthManager())
+}

--- a/hamrahIOS/NativeAuthManager.swift
+++ b/hamrahIOS/NativeAuthManager.swift
@@ -18,8 +18,8 @@ class NativeAuthManager: NSObject, ObservableObject {
     @Published var isLoading = false
     @Published var errorMessage: String?
     
-    private let baseURL = "https://hamrah.app" // Use production server
-    private var accessToken: String?
+    let baseURL = "https://hamrah.app" // Use production server
+    var accessToken: String?
     
     struct HamrahUser: Codable {
         let id: String


### PR DESCRIPTION
## Summary
• Add comprehensive My Account page displaying user info (ID, email, name, auth method, member since)
• Implement passkey management functionality (list, add, remove) matching web version capabilities  
• Create native iOS passkey operations using AuthenticationServices framework
• Integrate with existing backend APIs for WebAuthn credential management

## Test plan
- [x] Build and compile successfully
- [ ] Test My Account page displays user information correctly
- [ ] Test passkey listing functionality
- [ ] Test adding new passkeys via native iOS WebAuthn
- [ ] Test removing existing passkeys
- [ ] Verify API integration with backend endpoints
- [ ] Test navigation flow from main app to account page

🤖 Generated with [Claude Code](https://claude.ai/code)