### PR TITLE
Fix authentication completion issue in progressive auth flow

### DIFF
--- a/hamrah-ios/ProgressiveAuthManager.swift
+++ b/hamrah-ios/ProgressiveAuthManager.swift
@@ -53,7 +53,12 @@ class ProgressiveAuthManager: ObservableObject {
             if authManager.isTokenExpiringSoon() {
                 await attemptTokenRefresh()
             } else {
-                await completeAuthentication()
+                await MainActor.run {
+                    currentState = .validToken
+                    isLoading = false
+                    errorMessage = nil
+                }
+                print("✅ Valid token found, authentication already complete")
                 return
             }
         } else {
@@ -218,7 +223,7 @@ class ProgressiveAuthManager: ObservableObject {
     }
     
     var isProgressiveAuthComplete: Bool {
-        return currentState == .authenticated
+        return currentState == .authenticated || currentState == .validToken
     }
     
     var shouldShowBiometricPrompt: Bool {


### PR DESCRIPTION
Fixed the issue where the debug overlay showed auth as successful (✅) but completion as failed (❌).

**Problem:**
- `isProgressiveAuthComplete` only returned true for `.authenticated` state, not `.validToken`
- When users had valid tokens, the state was set to `.validToken` but completion check failed
- This caused confusion in the UI debug overlay

**Solution:**
1. Updated `isProgressiveAuthComplete` to return true for both `.authenticated` and `.validToken` states
2. Improved token validation flow to properly set `.validToken` state when valid token is found
3. Avoided unnecessary `completeAuthentication()` calls for already-valid tokens

**Files Changed:**
- ProgressiveAuthManager.swift:221 - Fixed completion check logic
- ProgressiveAuthManager.swift:56-62 - Improved valid token flow

🤖 Generated with [Claude Code](https://claude.ai/code)