### PR TITLE
Fix 405 error when loading passkeys in settings screen

### DIFF
--- a/hamrah-ios/MyAccountView.swift
+++ b/hamrah-ios/MyAccountView.swift
@@ -412,8 +412,12 @@ struct MyAccountView: View {
     }
     
     private func fetchPasskeys(accessToken: String) async throws -> [PasskeyCredential] {
+        guard let userId = authManager.currentUser?.id else {
+            throw NSError(domain: "API", code: -1, userInfo: [NSLocalizedDescriptionKey: "User ID not available"])
+        }
+        
         return try await SecureAPIService.shared.get(
-            endpoint: "/api/webauthn/credentials",
+            endpoint: "/api/webauthn/users/\(userId)/credentials",
             accessToken: accessToken,
             responseType: PasskeyListResponse.self
         ).credentials

--- a/hamrah-ios/NativeAuthManager.swift
+++ b/hamrah-ios/NativeAuthManager.swift
@@ -208,6 +208,11 @@ class NativeAuthManager: NSObject, ObservableObject {
             return false 
         }
         
+        guard let userId = currentUser?.id else {
+            print("🔍 No user ID available for passkey check")
+            return false
+        }
+        
         do {
             struct PasskeyCredentialsResponse: Codable {
                 let success: Bool
@@ -221,7 +226,7 @@ class NativeAuthManager: NSObject, ObservableObject {
             }
             
             let response = try await secureAPI.get(
-                endpoint: "/api/webauthn/credentials",
+                endpoint: "/api/webauthn/users/\(userId)/credentials",
                 accessToken: token,
                 responseType: PasskeyCredentialsResponse.self,
                 customBaseURL: webAppBaseURL
@@ -489,8 +494,13 @@ class NativeAuthManager: NSObject, ObservableObject {
     func validateAccessToken() async -> Bool {
         guard let token = accessToken else { return false }
         
+        guard let userId = currentUser?.id else { 
+            print("🔍 No user ID available for token validation")
+            return false 
+        }
+        
         // Try to validate with a backend endpoint that we know exists
-        let url = URL(string: "\(webAppBaseURL)/api/webauthn/credentials")!
+        let url = URL(string: "\(webAppBaseURL)/api/webauthn/users/\(userId)/credentials")!
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")


### PR DESCRIPTION
## Summary
• Fix 405 Method Not Allowed error when viewing passkeys in settings screen
• Update API endpoints to use correct user-specific passkey credentials endpoint
• Add proper user ID validation in authentication functions

## Root Cause
The iOS app was making GET requests to `/api/webauthn/credentials` which doesn't exist in the backend API. The correct endpoint is `/api/webauthn/users/{user_id}/credentials` which requires the user ID in the URL path.

## Changes Made
• **MyAccountView.swift:364-373** - Updated `fetchPasskeys()` to use correct endpoint with user ID validation
• **NativeAuthManager.swift:184-197** - Updated `checkPasskeyAvailability()` to use user-specific endpoint  
• **NativeAuthManager.swift:509-518** - Updated `validateAccessToken()` to use user-specific endpoint

## Test Plan
- [x] Build completes successfully without errors
- [ ] Test passkey loading in settings screen (should no longer return 405 error)
- [ ] Test passkey authentication flow still works correctly
- [ ] Verify token validation still functions properly

🤖 Generated with [Claude Code](https://claude.ai/code)