### PR TITLE
Fix 405 error when loading passkeys in settings screen

### DIFF
--- a/hamrah-ios/MyAccountView.swift
+++ b/hamrah-ios/MyAccountView.swift
@@ -412,8 +412,12 @@ struct MyAccountView: View {
     }
     
     private func fetchPasskeys(accessToken: String) async throws -> [PasskeyCredential] {
+        guard let userId = authManager.currentUser?.id else {
+            throw NSError(domain: "API", code: -1, userInfo: [NSLocalizedDescriptionKey: "User ID not available"])
+        }
+        
         return try await SecureAPIService.shared.get(
-            endpoint: "/api/webauthn/credentials",
+            endpoint: "/api/webauthn/users/\(userId)/credentials",
             accessToken: accessToken,
             responseType: PasskeyListResponse.self
         ).credentials

--- a/hamrah-ios/NativeAuthManager.swift
+++ b/hamrah-ios/NativeAuthManager.swift
@@ -208,6 +208,11 @@ class NativeAuthManager: NSObject, ObservableObject {
             return false 
         }
         
+        guard let userId = currentUser?.id else {
+            print("🔍 No user ID available for passkey check")
+            return false
+        }
+        
         do {
             struct PasskeyCredentialsResponse: Codable {
                 let success: Bool
@@ -221,7 +226,7 @@ class NativeAuthManager: NSObject, ObservableObject {
             }
             
             let response = try await secureAPI.get(
-                endpoint: "/api/webauthn/credentials",
+                endpoint: "/api/webauthn/users/\(userId)/credentials",
                 accessToken: token,
                 responseType: PasskeyCredentialsResponse.self,
                 customBaseURL: webAppBaseURL
@@ -489,8 +494,13 @@ class NativeAuthManager: NSObject, ObservableObject {
     func validateAccessToken() async -> Bool {
         guard let token = accessToken else { return false }
         
+        guard let userId = currentUser?.id else { 
+            print("🔍 No user ID available for token validation")
+            return false 
+        }
+        
         // Try to validate with a backend endpoint that we know exists
-        let url = URL(string: "\(webAppBaseURL)/api/webauthn/credentials")!
+        let url = URL(string: "\(webAppBaseURL)/api/webauthn/users/\(userId)/credentials")!
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")


### PR DESCRIPTION
- Update fetchPasskeys() to use correct API endpoint: GET /api/webauthn/users/{user_id}/credentials
- Update checkPasskeyAvailability() to use user-specific endpoint
- Update validateAccessToken() to use user-specific endpoint
- Add proper user ID validation in all affected functions

The previous endpoint /api/webauthn/credentials doesn't exist in the backend API, causing 405 Method Not Allowed errors. The correct endpoint requires the user ID in the URL path and is properly implemented in the backend.

🤖 Generated with [Claude Code](https://claude.ai/code)